### PR TITLE
add: 两个比赛、两个活动

### DIFF
--- a/data/activities.yml
+++ b/data/activities.yml
@@ -38,3 +38,56 @@
       timezone: Asia/Shanghai
       date: 2025年7月5日
       place: 中国，北京
+
+- title: 甜“芯”代码局：RISC-V 与 openKylin 的开源狂欢派对
+  description: 由进迭时空与 openKylin 社区共同举办的开源狂欢派对。左手甜点、右手代码，在 RISC-V 与 openKylin 的开源世界里，边吃边玩边搞技术！
+  category: activity
+  tags:
+    - RISC-V
+    - openKylin
+    - 城市沙龙
+  events:
+    - year: 2025
+      id: spacemitopenkylin250703
+      link: https://forum.spacemit.com/t/topic/604
+      timeline:
+        - deadline: '2025-07-03T14:00:00'
+          comment: '活动开始'
+        - deadline: '2025-07-03T18:00:00'
+          comment: '活动结束'
+      timezone: Asia/Shanghai
+      date: 2025 年 7 月 3 日
+      place: 中国，沈阳
+
+- title: UbuCon Asia
+  description: UbuCon Asia is a community-organized conference connecting Ubuntu community in Asia.
+  category: activity
+  tags:
+    - Ubuntu
+    - Conference
+  events:
+    - year: 2025
+      id: ubuconasia2025
+      link: https://2025.ubucon.asia/
+      timeline:
+        - deadline: '2025-03-01T00:00:00'
+          comment: 'Open day for Call for proposals & Travel grant application'
+        - deadline: '2025-03-31T00:00:00'
+          comment: 'Deadline for Call for proposals, Travel grant application for those who submitted proposals'
+        - deadline: '2025-04-15T00:00:00'
+          comment: 'Extended deadline for Call for proposals'
+        - deadline: '2025-04-28T00:00:00'
+          comment: 'Extended deadline for Travel grant application for those who submitted proposals'
+        - deadline: '2025-08-29T00:00:00'
+          comment: 'Arrival day'
+        - deadline: '2025-08-30T00:00:00'
+          comment: 'Fisrt day of UbuCon Asia 2025'
+        - deadline: '2025-08-31T00:00:00'
+          comment: 'Second day of UbuCon Asia 2025'
+        - deadline: '2025-09-01T00:00:00'
+          comment: 'Group tour program'
+        - deadline: '2025-09-02T00:00:00'
+          comment: 'Departure day'
+      timezone: Asia/Kathmandu
+      date: August 30 - 31
+      place: Kathmandu, Nepal

--- a/data/competitions.yml
+++ b/data/competitions.yml
@@ -124,7 +124,7 @@
       link: https://opensource.tencent.com/summer-of-code
       timeline:
         - deadline: '2025-06-20T00:00:00'
-          comment: '报名开始&开源基础课程开启'
+          comment: '报名开始 & 开源基础课程开启'
         - deadline: '2025-07-10T00:00:00'
           comment: '开源 issue 实践开启'
         - deadline: '2025-07-28T00:00:00'

--- a/data/competitions.yml
+++ b/data/competitions.yml
@@ -136,3 +136,61 @@
       timezone: Asia/Shanghai
       date: 2025 年 6 月 20 日 - 9 月 10 日
       place: 线上
+
+- title: Godot x openKylin 全国开发大赛
+  description: Godot x openKylin 全国开发大赛旨在鼓励开发者使用 Godot 引擎进行跨平台创作，推动开源生态发展。大赛聚焦游戏与软件创新，促进优秀作品在 openKylin 操作系统上的落地应用。
+  category: competition
+  tags:
+    - openKylin
+    - Godot
+    - 开源技术
+  events:
+    - year: 2025
+      id: gondc2025 # Godot x openKylin National Development Competition 首字母缩写
+      link: https://mp.weixin.qq.com/s/pYNHInIts4Rf0TH3joQVsQ
+      timeline:
+        - deadline: '2025-07-05T00:00:00'
+          comment: '报名 & 比赛开始'
+        - deadline: '2025-08-01T00:00:00'
+          comment: '作品提交开始'
+        - deadline: '2025-09-01T00:00:00'
+          comment: '报名截止'
+        - deadline: '2025-09-10T23:59:59'
+          comment: '比赛结束 & 作品提交截止'
+        - deadline: '2025-10-15T23:59:59'
+          comment: '评选结束'
+        - deadline: '2025-10-25T12:00:00'
+          comment: '颁奖结束'
+      timezone: Asia/Shanghai
+      date: 2025 年 7 月 5 日 - 10 月 25 日
+      place: 线上
+
+- title: 中国研究生操作系统开源创新大赛
+  description: 中国研究生操作系统开源创新大赛是面向研究生和本科生的全国性、公益性开源创新赛，由教育部学位管理与研究生教育司指导、中国学位与研究生教育学会和中国科协青少年科技中心主办。
+  category: competition
+  tags:
+    - 操作系统
+    - 开源技术
+  events:
+    - year: 2025
+      id: cpipc2
+      link: https://cpipc.acge.org.cn/cw/hp/2c9080178c7c917b018d1b1a0af61cd6
+      timeline:
+        - deadline: '2025-05-01T00:00:00'
+          comment: '报名开始'
+        - deadline: '2025-05-20T00:00:00'
+          comment: '作品提交开始'
+        - deadline: '2025-07-18T17:00:00'
+          comment: '报名截止'
+        - deadline: '2025-07-20T17:00:00'
+          comment: '作品提交截止'
+        - deadline: '2025-07-25T00:00:00'
+          comment: '初赛评审（具体时间待定）'
+        - deadline: '2025-07-30T00:00:00'
+          comment: '入围公示（具体时间待定）'
+        - deadline: '2025-08-25T00:00:00'
+          comment: '决赛（具体时间待定）'
+      timezone: Asia/Shanghai
+      date: 2025 年 5 月 1 日 - 8 月下旬
+      place: 线上
+


### PR DESCRIPTION
增加两个比赛、两个活动:
 - competition: Godot x openKylin 全国开发大赛
 - competition: 中国研究生操作系统开源创新大赛
 - activities: 甜“芯”代码局：RISC-V 与 openKylin 的开源狂欢派对
 - activities: UbuCon Asia

其中，甜“芯”代码局已于今日结束，但~~因其活动可畅享甜品冷饮的同时还有礼品相送~~作为相关 RISC-V 社区宣传而保留，Maintainer可视情况删除此项。
UbuCon Asia为 Ubuntu 亚洲社区会议，旨在连接亚洲的 Ubuntu 社区，今年在尼泊尔加德满都圣泽维尔学院举办，该活动 `timeline` 按照其官方的 _Important dates_ 整理而来，可能过于冗长，Maintainer 可视情况修订或删除此项。
中国研究生操作系统开源创新大赛部分时间暂未确定，`deadline` 中为预估时间，并在对应 `comment` 中附带有说明。