### PR TITLE
Add Huawei Open Source Lecture 5 activity details

### DIFF
--- a/data/activities.yml
+++ b/data/activities.yml
@@ -737,4 +737,4 @@
           comment: '讲堂结束'
       timezone: Asia/Shanghai # 所在时区
       date: 2025 年 10 月 17 日 # 人类可读的日期范围
-      place: 中国，北京；线上
+      place: 中国，北京


### PR DESCRIPTION
添加华为生态大讲堂第五讲的活动内容。
由于暂不确定构建系统是否支持单个活动在多个地点（线上+线下）同步举行，暂时使用全角中文分号隔开，填写在place字段中。后续若需要修改，则提交新的commit规范格式。