### PR TITLE
Add Open Atom Campus event in Shanghai for 2025

### DIFF
--- a/data/activities.yml
+++ b/data/activities.yml
@@ -780,3 +780,22 @@
       timezone: Asia/Shanghai # 所在时区
       date: 2025 年 10 月 15 日 # 人类可读的日期范围
       place: 中国，上海
+
+- title: 多模态数据湖与 Agentic AI——构建企业智能基座技术研讨会
+  description: 聚焦企业智能化核心挑战，通过多模态数据湖与 Agentic AI 技术闭环，提供端到端智能基座解决方案。活动涵盖数据平台重构、AI 开发范式革新、向量数据库应用及多模态集成实践，包含主题演讲与动手实验环节。
+  category: activity
+  tags:
+    - Agentic AI
+    - 企业智能化
+  events:
+    - year: 2025 # 年份
+      id: multimodal-agentic-ai-beijing-2025   # 全局唯一的ID
+      link: https://mp.weixin.qq.com/s/49GZZDKLzYfpbO2K1IJpMw # 链接
+      timeline:
+        - deadline: '2025-10-18T13:30:00' # 关键日期 (ISO 8601 格式)
+          comment: '活动开始' # 日期说明
+        - deadline: '2025-10-18T17:30:00'
+          comment: '活动结束'      
+      timezone: Asia/Shanghai # 所在时区
+      date: 2025 年 10 月 18 日 # 人类可读的日期范围
+      place: 中国，北京


### PR DESCRIPTION
Added a new activity entry for the Open Atom Campus event in Shanghai, including details about the event, its timeline, and location.