### PR TITLE
Add Open Atom Campus event details for Dalian University

### DIFF
--- a/data/activities.yml
+++ b/data/activities.yml
@@ -958,7 +958,7 @@
   tags:
     - 开放原子
     - 校源行
-    - OpenTenbase
+    - OpenTenBase
   events:
     - year: 2025 # 年份
       id: openatom-campus-udalian-2025  #全局唯一的ID


### PR DESCRIPTION
Added details for the Open Atom Campus event at Dalian University, including description, category, tags, and event timeline.